### PR TITLE
More gas

### DIFF
--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -14,7 +14,7 @@ logger = logging.getLogger('root.summa_relay.shared_eth')
 
 GWEI = 1000000000
 DEFAULT_GAS = 500_000
-DEFAULT_GAS_PRICE = 2 * GWEI
+DEFAULT_GAS_PRICE = 22 * GWEI
 
 CONNECTION: ethrpc.BaseRPC
 NONCE: Iterator[int]  # yields ints, takes no sends


### PR DESCRIPTION
Transactions are stalling on mainnet because we're not juicing  them
enough.  Pumping up the gas price to try and move things along for now.
This is temporary, we should at least make this value configurable on
the deployment level.