### PR TITLE
Gas Attack: Add basic gas price management

### DIFF
--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -220,7 +220,7 @@ async def _track_tx_result(tx: UnsignedEthTx, tx_id: str) -> None:
 
                 # Bradcast and set up tracking for the new tx, and stop watching
                 # this one.
-                sign_and_broadcast(newTx, False)
+                await sign_and_broadcast(newTx, False)
                 return
 
     if receipt_or_none is None:

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -125,6 +125,12 @@ async def sign_and_broadcast(
             # gas level if needed.
             asyncio.ensure_future(_track_tx_result(tx, ""))
             return
+        elif 'nonce too low' in err.args[0] and ticks > 0:
+            logger.warn(
+                f'Got an error {err} submitting nonce {tx.nonce} at gas price ' +
+                f'{tx.gasPrice}; assuming a lower-priced version cleared and ' +
+                f'continuing normally.'
+            )
         else:
             raise err # re-raise
 

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -134,7 +134,7 @@ async def sign_and_broadcast(
         else:
             raise err # re-raise
 
-    logger.info(f'dispatched transaction {tx_id} with gas price {tx.gasPrice}')
+    logger.info(f'dispatched transaction {tx_id} at nonce {tx.nonce} with gas price {tx.gasPrice}')
     if not ignore_result:
         asyncio.ensure_future(_track_tx_result(tx, tx_id, ticks))
 
@@ -256,7 +256,7 @@ async def _track_tx_result(tx: UnsignedEthTx, tx_id: str, ticks: int = 0) -> Non
 
     # This is reachable only when we've hit max gas.
     if receipt_or_none is None:
-        raise RuntimeError(f'No receipt after 10 minutes: {tx_id}')
+        raise RuntimeError(f'No receipt after 10 minutes: {tx_id}, nonce: {tx.nonce}, gas price: {tx.gasPrice}')
 
     receipt = cast(Receipt, receipt_or_none)
     logger.info(f'Receipt for {tx_id} status is {receipt["status"]}')

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -191,7 +191,7 @@ def _compute_tx_gas_price(tx_nonce, tx_ticks):
     '''Compute the proper gas price, adjusting for other pending txes and how
     long this tx has been pending, taking the max gas price into account.'''
     gas_price_factor = max(LATEST_PENDING_NONCE - tx_nonce + tx_ticks, 0)
-    adjusted_gas_price = (1 + gas_price_factor * 0.2) * DEFAULT_GAS_PRICE
+    adjusted_gas_price = round((1 + gas_price_factor * 0.2) * DEFAULT_GAS_PRICE)
 
     return max(min(adjusted_gas_price, MAX_GAS_PRICE), DEFAULT_GAS_PRICE)
 

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -143,7 +143,7 @@ def make_call_tx(
     if gas_price == -1:
         gas_price = min(
             # Let's make real sure there are no zero or negative gas prices, eh?
-            max(nonce - LATEST_PENDING_NONCE, 1) * DEFAULT_GAS_PRICE,
+            max(LATEST_PENDING_NONCE - n, 1) * DEFAULT_GAS_PRICE,
             MAX_GAS_PRICE)
 
     if nonce > LATEST_PENDING_NONCE:

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -60,7 +60,7 @@ async def init() -> None:
         # Get the already-mined count.
         mined_tx_count = int(await CONNECTION._RPC(
             method='eth_getTransactionCount',
-            params=[address, 'latest']), 16)
+            params=[address, 'latest']), 16) - 1
         logger.info(f'mined tx count is {mined_tx_count}')
 
         LATEST_PENDING_NONCE = await CONNECTION.get_nonce(address) - 1
@@ -74,9 +74,7 @@ async def init() -> None:
         #
         # If all pending nonces are already complete, make sure to start 1
         # ahead.
-        next_nonce = mined_tx_count
-        if mined_tx_count == LATEST_PENDING_NONCE:
-            next_nonce += 1
+        next_nonce = mined_tx_count + 1
         NONCE = _nonce(next_nonce)
         logger.info(f'next nonce is {next_nonce}')
 

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -213,7 +213,7 @@ def _adjust_gas_price(gas_price: int) -> int:
 def _compute_tx_gas_price(tx_nonce, tx_ticks):
     '''Compute the proper gas price, adjusting for other pending txes and how
     long this tx has been pending, taking the max gas price into account.'''
-    gas_price_factor = max(2**(LATEST_PENDING_NONCE - tx_nonce) + tx_ticks, 0)
+    gas_price_factor = max((LATEST_PENDING_NONCE - tx_nonce + 1) * tx_ticks, 0)
     adjusted_gas_price = round((1 + gas_price_factor * 0.2) * DEFAULT_GAS_PRICE)
 
     return max(min(adjusted_gas_price, MAX_GAS_PRICE), DEFAULT_GAS_PRICE)

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -225,9 +225,13 @@ async def _track_tx_result(tx: UnsignedEthTx, tx_id: str, ticks: int = 0) -> Non
     latest_gas_price = tx.gasPrice
 
     for _ in range(20):
-        await asyncio.sleep(30)
         receipt_or_none = None
+
+        # For a blank tx_id, skip the sleep and go straight to cranking gas.
+        # Blank tx_ids are really just us trying to catch up to the latest used
+        # gas price.
         if tx_id != "":
+            await asyncio.sleep(30)
             receipt_or_none = await CONNECTION.get_tx_receipt(tx_id)
 
         if receipt_or_none is not None:

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -203,7 +203,7 @@ def _adjust_gas_price(gas_price: int) -> int:
 def _compute_tx_gas_price(tx_nonce, tx_ticks):
     '''Compute the proper gas price, adjusting for other pending txes and how
     long this tx has been pending, taking the max gas price into account.'''
-    gas_price_factor = max(LATEST_PENDING_NONCE - tx_nonce + tx_ticks, 0)
+    gas_price_factor = max(2**(LATEST_PENDING_NONCE - tx_nonce) + tx_ticks, 0)
     adjusted_gas_price = round((1 + gas_price_factor * 0.2) * DEFAULT_GAS_PRICE)
 
     return max(min(adjusted_gas_price, MAX_GAS_PRICE), DEFAULT_GAS_PRICE)
@@ -244,6 +244,7 @@ async def _track_tx_result(tx: UnsignedEthTx, tx_id: str, ticks: int = 0) -> Non
                 await sign_and_broadcast(newTx, False, ticks)
                 return
 
+    # This is reachable only when we've hit max gas.
     if receipt_or_none is None:
         raise RuntimeError(f'No receipt after 10 minutes: {tx_id}')
 

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('root.summa_relay.shared_eth')
 GWEI = 1000000000
 DEFAULT_GAS = 500_000
 DEFAULT_GAS_PRICE = 20 * GWEI
-MAX_GAS_PRICE = 80 * GWEI
+MAX_GAS_PRICE = 120 * GWEI
 
 CONNECTION: ethrpc.BaseRPC
 NONCE: Iterator[int]  # yields ints, takes no sends

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -225,8 +225,8 @@ async def _track_tx_result(tx: UnsignedEthTx, tx_id: str) -> None:
                     data = tx.data,
                     chainId = tx.chainId)
 
-                # Bradcast and set up tracking for the new tx, and stop watching
-                # this one.
+                # Broadcast and set up tracking for the new tx, and stop
+                # watching this one.
                 await sign_and_broadcast(newTx, False)
                 return
 

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -73,7 +73,13 @@ async def init() -> None:
         # unconfirmed nonce having already been mined---this is fine, the
         # process can be restarted and will read the latest pending and mined
         # state at that time.
-        NONCE = _nonce(LATEST_COMPLETE_NONCE)
+        #
+        # If all pending nonces are already complete, make sure to start 1
+        # ahead.
+        next_nonce = LATEST_COMPLETE_NONCE
+        if LATEST_COMPLETE_NONCE == LATEST_PENDING_NONCE:
+            next_nonce += 1
+        NONCE = _nonce(next_nonce)
         logger.info(f'next nonce is {LATEST_COMPLETE_NONCE}')
 
 async def close_connection() -> None:

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -240,7 +240,7 @@ async def _track_tx_result(tx: UnsignedEthTx, tx_id: str, ticks: int = 0) -> Non
 
                 # Broadcast and set up tracking for the new tx, and stop
                 # watching this one.
-                await sign_and_broadcast(newTx, True, ticks)
+                await sign_and_broadcast(newTx, False, ticks)
                 return
 
     if receipt_or_none is None:

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -254,8 +254,7 @@ async def _track_tx_result(tx: UnsignedEthTx, tx_id: str, ticks: int = 0) -> Non
                     chainId = tx.chainId)
 
                 # Broadcast and set up tracking for the new tx, and stop
-                # watching this one.
-                await sign_and_broadcast(newTx, False, ticks)
+                asyncio.ensure_future(sign_and_broadcast(newTx, False, ticks))
                 return
 
     # This is reachable only when we've hit max gas.

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -100,6 +100,7 @@ async def sign_and_broadcast(
     if privkey is None and unlock_code is None:
         raise RuntimeError('Attempted to sign tx without access to key')
 
+    logger.info(f'dispatching transaction at nonce {tx.nonce} with gas price {tx.gasPrice}')
     try:
         if privkey is None:
             logger.debug('signing with ether node')
@@ -118,8 +119,7 @@ async def sign_and_broadcast(
         else:
             raise err # re-raise
 
-
-    logger.info(f'dispatched transaction {tx_id}')
+    logger.info(f'dispatched transaction {tx_id} with gas price {tx.gasPrice}')
     if not ignore_result:
         asyncio.ensure_future(_track_tx_result(tx, tx_id, ticks))
 

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -144,7 +144,7 @@ def make_call_tx(
     if gas_price == -1:
         gas_price = min(
             # Let's make real sure there are no zero or negative gas prices, eh?
-            max(LATEST_PENDING_NONCE - n, 1) * DEFAULT_GAS_PRICE,
+            max(LATEST_PENDING_NONCE - nonce, 1) * DEFAULT_GAS_PRICE,
             MAX_GAS_PRICE)
 
     if nonce > LATEST_PENDING_NONCE:

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -73,8 +73,8 @@ async def init() -> None:
         # unconfirmed nonce having already been mined---this is fine, the
         # process can be restarted and will read the latest pending and mined
         # state at that time.
-        NONCE = _nonce(LATEST_COMPLETE_NONCE + 1)
-        logger.info(f'next nonce is {LATEST_COMPLETE_NONCE + 1}')
+        NONCE = _nonce(LATEST_COMPLETE_NONCE)
+        logger.info(f'next nonce is {LATEST_COMPLETE_NONCE}')
 
 async def close_connection() -> None:
     try:

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -201,7 +201,7 @@ async def _track_tx_result(tx: UnsignedEthTx, tx_id: str) -> None:
 
     # Number of ticks since submission occurred without a receipt.
     ticks = 0
-    latest_gas_price = tx.gas_price
+    latest_gas_price = tx.gasPrice
 
     for _ in range(20):
         await asyncio.sleep(30)

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -61,6 +61,7 @@ async def init() -> None:
         mined_tx_count = int(await CONNECTION._RPC(
             method='eth_getTransactionCount',
             params=[address, 'latest']), 16)
+        logger.info(f'mined tx count is {mined_tx_count}')
 
         LATEST_PENDING_NONCE = await CONNECTION.get_nonce(address) - 1
         logger.info(f'latest pending nonce is {LATEST_PENDING_NONCE}')


### PR DESCRIPTION
The basic mechanism now is:
- We track this transaction's nonce vs the highest pending transaction nonce.
- We also track the number of ticks a transaction has been waiting (each tick is 30s).
- We multiple ticks by the number of transactions ahead of this one, and then apply a 20% factor increase for unit from that multiplication. This has the effect of significantly boosting the gas price every time a new transaction is blocked by the current one.

To handle reboots, error handling has changed so that if we get a `transaction underpriced` or `already known` error, we boost the gas price until we don't see this. That allows a newly booted instance that's resubmitting older transactions to reach the same state as the previous instance. And finally, to handle instances that are catching up to latest chain state, failing to find an LCA after 5 attempts (which are time-based rather than tx-based right now) doesn't crash; instead, it retries after a 60s pause.

Finally, max gas is now 120 gwei.