### PR TITLE
Molotov Cocktail: Light gas prices on fire and throw them into the building

### DIFF
--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -14,8 +14,8 @@ logger = logging.getLogger('root.summa_relay.shared_eth')
 
 GWEI = 1000000000
 DEFAULT_GAS = 500_000
-DEFAULT_GAS_PRICE = 20 * GWEI
-MAX_GAS_PRICE = 120 * GWEI
+DEFAULT_GAS_PRICE = 100 * GWEI
+MAX_GAS_PRICE = 600 * GWEI
 
 CONNECTION: ethrpc.BaseRPC
 NONCE: Iterator[int]  # yields ints, takes no sends

--- a/maintainer/maintainer/ethereum/shared.py
+++ b/maintainer/maintainer/ethereum/shared.py
@@ -214,7 +214,7 @@ def _compute_tx_gas_price(tx_nonce, tx_ticks):
     '''Compute the proper gas price, adjusting for other pending txes and how
     long this tx has been pending, taking the max gas price into account.'''
     gas_price_factor = max((LATEST_PENDING_NONCE - tx_nonce + 1) * tx_ticks, 0)
-    adjusted_gas_price = round((1 + gas_price_factor * 0.2) * DEFAULT_GAS_PRICE)
+    adjusted_gas_price = round((1 + gas_price_factor * 0.5) * DEFAULT_GAS_PRICE)
 
     return max(min(adjusted_gas_price, MAX_GAS_PRICE), DEFAULT_GAS_PRICE)
 


### PR DESCRIPTION
This PR increase the default and max gas prices used in transaction
submission, and makes the curve used to increase prices more aggressive.

More details on the aggressiveness increase from the commit message:

```
Right now the wait unit is the product of how many pending transactions
are ahead of this one (generally only revelevant during relay catch-up)
and the number of ticks this transaction has gone unmined (with one tick
= 30 seconds). We were cranking up by 20% of this wait unit multipled by
default gas every tick, but this commit adjusts it to crank up by 50% of
the wait unit * default gas. For a linear wait unit increase, which is
the standard expected behavior, this yields:

  Time  | Gas Price
--------------------
   0    | 100 gwei
  30s   | 150 gwei
  60s   | 200 gwei
 1m30s  | 250 gwei
  2m    | 350 gwei
 2m30s  | 400 gwei
  3m    | 450 gwei
 3m30s  | 500 gwei
  4m    | 550 gwei

With recent gas prices, this should mean relay information should land
within 4-5 minutes when gas prices are high, but much faster and cheaper
when prices are lower. If this feels too long or gas prices become more
volatile still, the numbers can be adjusted.
```