### PR TITLE
Configurable Gas Price

### DIFF
--- a/maintainer/maintainer/config/.sample.env
+++ b/maintainer/maintainer/config/.sample.env
@@ -40,3 +40,9 @@ SUMMA_RELAY_INFURA_KEY=""
 # no default
 # target relay smart contract address
 SUMMA_RELAY_CONTRACT=0x...
+
+# default: 100
+DEFAULT_GAS_PRICE_GWEI=100
+
+# default: 600
+MAX_GAS_PRICE_GWEI=600

--- a/maintainer/maintainer/config/__init__.py
+++ b/maintainer/maintainer/config/__init__.py
@@ -86,6 +86,8 @@ def set() -> RelayConfig:
         BCOIN_WS_URL=f'ws://{BCOIN_HOST}:{BCOIN_PORT}',
         PROJECT_ID=os.environ.get('SUMMA_RELAY_INFURA_KEY', ''),
         CONTRACT=os.environ.get('SUMMA_RELAY_CONTRACT', ''),
+        DEFAULT_GAS_PRICE_GWEI=os.environ.get('DEFAULT_GAS_PRICE_GWEI', 100),
+        MAX_GAS_PRICE_GWEI=os.environ.get('MAX_GAS_PRICE_GWEI', 600),
     )
 
     return CONFIG


### PR DESCRIPTION
We let DEFAULT_GAS_PRICE used for transaction submission and MAX_GAS_PRICE used as a limit for gas price bumps to be configurable instead of hardcoding them.

The default values will be set the same as previously hardcoded:
DEFAULT_GAS_PRICE = 100 Gwei
MAX_GAS_PRICE = 600 Gwei

Having it configurable is better from a multi-environment perspective, as it doesn't make sense to start with 100 Gwei on Ropsten.

It also gives a possibility to easily tweak settings for the mainnet without the need to rebuild the code.

The following properties can be used to configure it: `DEFAULT_GAS_PRICE_GWEI` and `MAX_GAS_PRICE_GWEI`. Note that configured values are expected to be provided in Gwei (not wei!).